### PR TITLE
Fix For no Release Event Received

### DIFF
--- a/src/qanGroupItem.cpp
+++ b/src/qanGroupItem.cpp
@@ -267,6 +267,11 @@ void    GroupItem::mousePressEvent(QMouseEvent* event)
         if (getGraph())
             getGraph()->selectGroup(*getGroup(), event->modifiers());
     }
+}
+
+void    GroupItem::mouseReleaseEvent(QMouseEvent* event)
+{
+    qan::NodeItem::mouseReleaseEvent(event);
 
     if (event->button() == Qt::LeftButton)
         emit groupClicked(this, event->localPos());

--- a/src/qanGroupItem.h
+++ b/src/qanGroupItem.h
@@ -214,6 +214,7 @@ signals:
 protected:
     virtual void    mouseDoubleClickEvent(QMouseEvent* event ) override;
     virtual void    mousePressEvent(QMouseEvent* event ) override;
+    virtual void    mouseReleaseEvent(QMouseEvent* event ) override;
 
 signals:
     //! Emitted whenever the group is clicked (even at the start of a dragging operation).


### PR DESCRIPTION
When certain custom actions like showing a QMenu
are done in a slot connected to the groupRightClicked() signal which gets emitted in qanGroupItem::mousePressEvent() the release event of the mouse button is never handled by the QTQuick framework and e.g. the grabber item is not cleared and will be re-used in the next mouse press event.

This is fixed by moving the emit of 'groupRightClicked()' to the mouseReleaseEvent() handler.